### PR TITLE
Add PDF-to-audio converter using GPT models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # pdf-reader
+
+This repository contains a simple Python script that converts a PDF into an audio narration.
+
+The script performs two steps for every page of a PDF:
+
+1. **Transcription** – Each page is rendered as an image and sent to an OpenAI chat model (`gpt-5` by default). The model is asked to transcribe the text in natural reading order.
+2. **Text‑to‑Speech** – The concatenated transcription is passed to the `gpt-4o-mini-tts` model to generate an audio file.
+
+## Requirements
+- Python 3.10+
+- `openai` and `pymupdf` packages
+- `OPENAI_API_KEY` environment variable set
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python pdf_to_audio.py input.pdf output.mp3
+```
+
+By default all pages are processed. For testing you can limit the number of pages:
+
+```bash
+python pdf_to_audio.py input.pdf output.mp3 --max-pages 1
+```
+
+Models can be overridden using environment variables:
+
+```bash
+export TRANSCRIPTION_MODEL=gpt-5
+export TTS_MODEL=gpt-4o-mini-tts
+```
+
+## Testing with a Mocked API
+
+The project includes a minimal mock of the OpenAI client so the script can be
+tested without network access. Enable the mock by setting `MOCK_OPENAI=1`:
+
+```bash
+MOCK_OPENAI=1 python pdf_to_audio.py example.pdf output.mp3 --max-pages 1
+```
+
+Run automated tests with:
+
+```bash
+pytest
+```

--- a/pdf_to_audio.py
+++ b/pdf_to_audio.py
@@ -1,0 +1,131 @@
+import argparse
+import base64
+import os
+from pathlib import Path
+
+import fitz  # PyMuPDF
+from openai import OpenAI
+
+
+class _MockStreamingResponse:
+    """Simple context manager that writes canned audio bytes to a file."""
+
+    def __init__(self, data=b"mock audio"):
+        self._data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def stream_to_file(self, path):
+        with open(path, "wb") as fh:
+            fh.write(self._data)
+
+
+class _MockResponses:
+    def create(self, *args, **kwargs):
+        class _Resp:
+            output_text = "Mock transcription"
+
+        return _Resp()
+
+
+class _MockAudioSpeech:
+    class WithStreamingResponse:
+        def create(self, *args, **kwargs):
+            return _MockStreamingResponse()
+
+    with_streaming_response = WithStreamingResponse()
+
+
+class _MockAudio:
+    speech = _MockAudioSpeech()
+
+
+class MockOpenAI:
+    """Minimal mock of the OpenAI client used for testing."""
+
+    def __init__(self, *args, **kwargs):
+        self.responses = _MockResponses()
+        self.audio = _MockAudio()
+
+
+def get_client():
+    """Return real or mock OpenAI client depending on environment."""
+    if os.getenv("MOCK_OPENAI") == "1":
+        return MockOpenAI()
+    return OpenAI()
+
+
+def render_pdf_to_images(pdf_path):
+    doc = fitz.open(pdf_path)
+    images = []
+    for page in doc:
+        pix = page.get_pixmap(dpi=200)
+        images.append(pix.tobytes("png"))
+    doc.close()
+    return images
+
+
+def transcribe_page(image_bytes, client, model):
+    b64_image = base64.b64encode(image_bytes).decode("utf-8")
+    response = client.responses.create(
+        model=model,
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "Transcribe the text from this page of a PDF in natural reading order. Return only the plain text.",
+                    },
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/png;base64,{b64_image}",
+                    },
+                ],
+            }
+        ],
+    )
+    return response.output_text.strip()
+
+
+def text_to_speech(text, output_path, client, model, voice="alloy"):
+    output_file = Path(output_path)
+    with client.audio.speech.with_streaming_response.create(
+        model=model,
+        voice=voice,
+        input=text,
+    ) as response:
+        response.stream_to_file(output_file)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert a PDF into an audio file using OpenAI APIs.")
+    parser.add_argument("pdf", help="Path to input PDF file")
+    parser.add_argument("output", help="Path to output audio file (e.g., output.mp3)")
+    parser.add_argument("--max-pages", type=int, default=None, help="Limit number of pages for processing (for testing)")
+    args = parser.parse_args()
+
+    client = get_client()
+
+    images = render_pdf_to_images(args.pdf)
+    texts = []
+    total_pages = len(images)
+    for idx, img in enumerate(images, start=1):
+        if args.max_pages is not None and idx > args.max_pages:
+            break
+        print(f"Transcribing page {idx}/{total_pages}...")
+        page_text = transcribe_page(img, client, model=os.getenv("TRANSCRIPTION_MODEL", "gpt-5"))
+        texts.append(page_text)
+
+    full_text = "\n".join(texts)
+    print("Generating audio...")
+    text_to_speech(full_text, args.output, client, model=os.getenv("TTS_MODEL", "gpt-4o-mini-tts"))
+    print(f"Saved audio to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai
+pymupdf
+pytest

--- a/tests/test_pdf_to_audio.py
+++ b/tests/test_pdf_to_audio.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pdf_to_audio
+
+
+def test_pdf_to_audio_with_mock(tmp_path, monkeypatch):
+    output = tmp_path / "out.mp3"
+    monkeypatch.setenv("MOCK_OPENAI", "1")
+    monkeypatch.setattr(sys, "argv", [
+        "pdf_to_audio.py",
+        str(Path("example.pdf")),
+        str(output),
+        "--max-pages",
+        "1",
+    ])
+    pdf_to_audio.main()
+    assert output.exists()
+    assert output.read_bytes() == b"mock audio"


### PR DESCRIPTION
## Summary
- implement `pdf_to_audio.py` to transcribe PDF pages with GPT and generate TTS audio
- document usage and dependency installation in README
- add requirements file
- add mock OpenAI client and tests for offline validation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `MOCK_OPENAI=1 python pdf_to_audio.py example.pdf test.mp3 --max-pages 1`


------
https://chatgpt.com/codex/tasks/task_e_68b293148f14832abb09ef893fce635a